### PR TITLE
qt: fix make qt-osx build regression

### DIFF
--- a/frontends/qt/Makefile
+++ b/frontends/qt/Makefile
@@ -30,7 +30,7 @@ linux:
 	chrpath -r $$ORIGIN/lib server/libbreez_sdk_bindings.so
 	cd server && $(MAKE) linux
 	$(MAKE) base
-    mkdir -p build/linux-tmp/lib build/linux
+	mkdir -p build/linux-tmp/lib build/linux
 	mv build/BitBox build/linux-tmp
 	cp build/assets.rcc build/linux-tmp/
 	cp server/libserver.so build/linux-tmp


### PR DESCRIPTION
Makefile complained something wrong on line 33, looks like some spaces issue. Regression in 4427b51d84f4899809cbc226f54f2626d4947ba9